### PR TITLE
Updated ConfigFileTable- removed old API reference

### DIFF
--- a/src/com/esn/idea/liquibaseejb/facet/ConfigFilesTableModel.java
+++ b/src/com/esn/idea/liquibaseejb/facet/ConfigFilesTableModel.java
@@ -139,7 +139,7 @@ public class ConfigFilesTableModel implements TableModel
     private VirtualFile[] chooseFromDescriptor(FileChooserDescriptor chooserDescriptor)
     {
         FileChooserFactory fileChooserFactory = FileChooserFactory.getInstance();
-        FileChooserDialog fileChooserDialog = fileChooserFactory.createFileChooser(chooserDescriptor, module.getProject());
+        FileChooserDialog fileChooserDialog = fileChooserFactory.createFileChooser(chooserDescriptor, module.getProject(), null);
 
         VirtualFile moduleFile = module.getModuleFile();
         VirtualFile chooseRoot = moduleFile;


### PR DESCRIPTION
- As of IntelliJ IDEA 13, the FileChooserFactory.createFileChooser
  method requires you to pass a parent component.
  However, it does allow you to pass a NULL parent object.
